### PR TITLE
Parse Simplest form of Set Evidence in Semant

### DIFF
--- a/src/absyn/BlogProgram.cpp
+++ b/src/absyn/BlogProgram.cpp
@@ -36,6 +36,10 @@ const std::vector<Stmt*>& BlogProgram::getAll() {
   return args;
 }
 
+std::vector<Stmt*>& BlogProgram::getAllRef() {
+  return args;
+}
+
 // For Debugging Use
 void BlogProgram::print(FILE* file, int indent) {
   fprintf(file, "%*s(BlogProgram:\n", indent, "");

--- a/src/absyn/BlogProgram.h
+++ b/src/absyn/BlogProgram.h
@@ -60,6 +60,7 @@ public:
   void add(Stmt* decl);
   Stmt* get(int k);
   const std::vector<Stmt*>& getAll();
+  std::vector<Stmt*>& getAllRef();
 
   // For Debugging Use
   void print(FILE* file, int indent);

--- a/src/absyn/CondSet.cpp
+++ b/src/absyn/CondSet.cpp
@@ -26,6 +26,11 @@ Expr* CondSet::getCond() {
   return size() > 0 ? get(0) : nullptr;
 }
 
+void CondSet::setCond(Expr* c) {
+  if (args.size() < 1) args.push_back(c);
+  else args[0] = c;
+}
+
 // For Debugging Use
 void CondSet::print(FILE* file, int indent) {
   fprintf(file, "%*s(CondSet:\n", indent, "");

--- a/src/absyn/CondSet.h
+++ b/src/absyn/CondSet.h
@@ -20,6 +20,8 @@ public:
   Expr* getCond();
   VarDecl& getVar();
 
+  void setCond(Expr* c);
+
   // For Debugging Use
   void print(FILE *file, int indent);
 private:

--- a/src/absyn/Evidence.cpp
+++ b/src/absyn/Evidence.cpp
@@ -29,6 +29,14 @@ Expr* Evidence::getRight() {
   return right;
 }
 
+void Evidence::setLeft(Expr* e) {
+  left = e;
+}
+
+void Evidence::setRight(Expr* e) {
+  right = e;
+}
+
 // For Debugging Use
 void Evidence::print(FILE* file, int indent) {
   fprintf(file, "%*s(Evidence:\n", indent, "");

--- a/src/absyn/Evidence.h
+++ b/src/absyn/Evidence.h
@@ -22,6 +22,8 @@ public:
 
   Expr* getLeft();
   Expr* getRight();
+  void setLeft(Expr* e);
+  void setRight(Expr *);
 
   // For Debugging Use
   void print(FILE* file, int indent);

--- a/src/semant/Semant.cpp
+++ b/src/semant/Semant.cpp
@@ -39,6 +39,9 @@ ir::BlogModel* Semant::getModel() {
 }
 
 void Semant::process(absyn::BlogProgram* prog) {
+  // Process Set Evidence
+  processSetEvidence(prog);
+
   processDeclarations(prog);
   processBodies(prog);
   // add TypeDomains to model
@@ -50,6 +53,64 @@ void Semant::process(absyn::BlogProgram* prog) {
   // Add Functions
   for (auto p : functory.getAllFuncTable())
     model->addFunction(std::shared_ptr<ir::FuncDefn>(p.second));
+}
+
+void Semant::processSetEvidence(absyn::BlogProgram* prog) {
+  // Note: It is reference here! We have to modify the BLOG program!
+  std::vector<absyn::Stmt*>& all = prog->getAllRef();
+  for (size_t i = 0; i < all.size(); ++i) {
+    absyn::Evidence* ev = dynamic_cast<absyn::Evidence*>(all[i]);
+    if (ev == NULL) continue;
+    absyn::CondSet* lt = dynamic_cast<absyn::CondSet*>(ev->getLeft());
+    absyn::ListSet* rt = dynamic_cast<absyn::ListSet*>(ev->getRight());
+    if (lt == NULL || rt == NULL) continue;
+    int line = rt->line, col = rt->col;
+    // Set Evidence: obs {CondSet} = {ListSet}
+    // :::=> obs {} = int literal
+
+    // TODO: IMPORTANT!!!
+    //   We current do not have clone method for Absyn instances!!!
+    //   So we do not support conditional set!!!
+    absyn::Expr* cd = lt->getCond();
+    if (cd != NULL) {
+      error(cd->line, cd->col, "For Evidence Set, We DO NOT support condition for Cond Set now.");
+      return ;
+    }
+    lt->setCond(NULL);
+    // TODO: IMPORTANT!!!
+    //   due to lack of clone method, 
+    //      we only support list set containing VarRef
+    std::vector<absyn::Symbol> sym;
+    for (size_t k = 0; k < rt->size(); ++k) {
+      auto ref = dynamic_cast<absyn::VarRef*>(rt->get(k));
+      if (ref == NULL) {
+        error(rt->line, rt->col, "For Evidence Set, We Only Support VarRef in the List Set.");
+        return ;
+      }
+      sym.push_back(ref->getVar());
+    }
+
+    // Modify BLOG Program now!
+    absyn::VarDecl var = lt->getVar();
+    ev->setLeft(new absyn::CardinalityExpr(line, col, lt));
+    ev->setRight(new absyn::IntLiteral(line, col, rt->size()));
+    // :::=> randon <element> ~ UniformChoice({T t: t != prev})
+    for (size_t k = 0; k < sym.size(); ++k) {
+      auto dist = new absyn::DistrExpr(line, col, absyn::Symbol("UniformChoice"));
+      absyn::Expr* root = NULL;
+      for (size_t p = 0; p < k; ++p) {
+        auto cur = new absyn::OpExpr(line, col, absyn::AbsynConstant::NEQ, 
+          new absyn::VarRef(line, col, var.getVar()), new absyn::VarRef(line, col, sym[p]));
+        if (root == NULL) root = cur;
+        else 
+          root = new absyn::OpExpr(line,col,absyn::AbsynConstant::AND, root, cur);
+      }
+      auto arg = new absyn::CondSet(line,col,var,root);
+      dist->add(arg);
+      auto func = new absyn::FuncDecl(line, col, true, var.getTyp(), sym[k], dist);
+      all.push_back(func);
+    }
+  }
 }
 
 void Semant::processDeclarations(absyn::BlogProgram* prog) {

--- a/src/semant/Semant.h
+++ b/src/semant/Semant.h
@@ -29,6 +29,16 @@ public:
   bool Okay();
 private:
   /**
+   * process set evidence
+   *    i.e.  obs {T t} = {t1,t2}
+   * :::=>
+   *      obs #{T t} = 2;
+   *      random t1 ~ UniformChoice({T t});
+   *      random t2 ~ UniformChoice({T t: t1 != t2})
+   */
+  void processSetEvidence(absyn::BlogProgram* prog);
+
+  /**
    * process all declarations, including
    *   - type declaration
    *   - distinct symbols

--- a/src/test/absyn/AircraftSimple.cpp
+++ b/src/test/absyn/AircraftSimple.cpp
@@ -56,11 +56,17 @@ void AircraftSimple::build(){
     blog->add(num);
   }
   /*
-  obs #Blip = 3;
+  obs {Blip b} = {b1, b2, b3};
   */
   {
-    CardinalityExpr* num = new CardinalityExpr(0, 0, new CondSet(0, 0, VarDecl(0, 0, Symbol("Blip"))));
-    Evidence* e = new Evidence(0, 0, num, new IntLiteral(0,0,3));
+    CondSet* st = new CondSet(0, 0, VarDecl(0,0,Symbol("Blip"),Symbol("b")));
+    ListSet* lst = new ListSet(0,0);
+    lst->add(new VarRef(0, 0, Symbol("b1")));
+    lst->add(new VarRef(0, 0, Symbol("b2")));
+    lst->add(new VarRef(0, 0, Symbol("b3")));
+//    CardinalityExpr* num = new CardinalityExpr(0, 0, new CondSet(0, 0, VarDecl(0, 0, Symbol("Blip"))));
+//    Evidence* e = new Evidence(0, 0, num, new IntLiteral(0,0,3));
+    Evidence* e = new Evidence(0,0,st,lst); // Set Evidence Here!
     blog->add(e);
   }
 


### PR DESCRIPTION
Can Only Process
obs {T t} = {t1, t2, t3}
No Condition supported in condset
Only VarRef supported in listset
